### PR TITLE
Use a cache key of IP/port

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,12 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:0250441ac9f681c839722297897952ee6d633f2a37dc254eca9d6d21bd1e877d"
+  digest = "1:cdf3df431e70077f94e14a99305808e3d13e96262b4686154970f448f7248842"
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
   pruneopts = "UT"
-  revision = "137b63e61fe55e0aea7df466931198c37817f743"
-  version = "0.18.0"
+  revision = "1c9e12237046fccc3e23b9ca79d0c904157e89ad"
+  version = "0.18.2"
 
 [[projects]]
   digest = "1:fd718cd10034b5b4e3151e3a563653e4144429343f59b1b3c3c8b59ae55207de"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas"
-  version = "0.18.0"
+  version = "0.18.2"
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"

--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-
 	"github.com/openfaas/faas/gateway/requests"
+
 	log "github.com/sirupsen/logrus"
 )
 

--- a/handlers/info.go
+++ b/handlers/info.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	//OrchestrationIdentifier identifier string for provider orchestration
+	// OrchestrationIdentifier identifier string for provider orchestration
 	OrchestrationIdentifier = "federation"
-	//ProviderName name of the provider
+	// ProviderName name of the provider
 	ProviderName = "faas-federation"
 )
 

--- a/handlers/logs.go
+++ b/handlers/logs.go
@@ -1,0 +1,20 @@
+// Copyright (c) OpenFaaS Author(s) 2019. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/openfaas-incubator/faas-federation/routing"
+	log "github.com/sirupsen/logrus"
+)
+
+// MakeLogHandler to read logs from an endpoint
+func MakeLogHandler(proxy http.HandlerFunc, providerLookup routing.ProviderLookup) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Info("log handler")
+
+		proxy.ServeHTTP(w, r)
+	}
+}

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -33,9 +33,8 @@ func MakeProxyHandler(proxy http.HandlerFunc) http.HandlerFunc {
 		functionName := strings.Split(r.URL.Path, "/")[2]
 		pathVars["name"] = functionName
 		pathVars["params"] = r.URL.Path
+		log.Infof("proxy request to: %s %s", functionName, r.URL.String())
 		proxy.ServeHTTP(w, r)
-
-		log.Infof("proxy request for function %s path %s", functionName, r.URL.String())
 	}
 }
 

--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -18,6 +18,7 @@ func MakeFunctionReader(providers []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		log.Info("read request")
+
 		functions, err := routing.ReadServices(providers)
 		if err != nil {
 			log.Printf("Error getting service list: %s\n", err.Error())
@@ -34,6 +35,7 @@ func MakeFunctionReader(providers []string) http.HandlerFunc {
 
 		functionBytes, _ := json.Marshal(result)
 		w.Header().Set("Content-Type", "application/json")
+
 		w.WriteHeader(http.StatusOK)
 		w.Write(functionBytes)
 	}

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 		DeleteHandler:  handlers.MakeDeleteHandler(proxyFunc),
 		DeployHandler:  handlers.MakeDeployHandler(proxyFunc, providerLookup),
 		FunctionReader: handlers.MakeFunctionReader(cfg.Providers),
-		ReplicaReader:  handlers.MakeReplicaReader(),
+		ReplicaReader:  handlers.MakeReplicaReader(providerLookup),
 		ReplicaUpdater: handlers.MakeReplicaUpdater(),
 		UpdateHandler:  handlers.MakeUpdateHandler(proxyFunc, providerLookup),
 		HealthHandler:  handlers.MakeHealthHandler(),

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 		UpdateHandler:  handlers.MakeUpdateHandler(proxyFunc, providerLookup),
 		HealthHandler:  handlers.MakeHealthHandler(),
 		InfoHandler:    handlers.MakeInfoHandler(version.BuildVersion(), version.GitCommitSHA),
+		LogHandler:     handlers.MakeLogHandler(proxyFunc, providerLookup),
 	}
 
 	bootstrapConfig := bootTypes.FaaSConfig{

--- a/routing/provider.go
+++ b/routing/provider.go
@@ -55,7 +55,8 @@ func NewDefaultProviderRouting(providers []string, defaultProvider string) (Prov
 }
 
 func (d *defaultProviderRouting) ReloadCache() error {
-	log.Info("reloading cache starting...")
+	log.Info("reloading cache started...")
+
 	var urls []string
 	for _, v := range d.providers {
 		urls = append(urls, v.String())
@@ -83,6 +84,7 @@ func (d *defaultProviderRouting) ReloadCache() error {
 
 func (d *defaultProviderRouting) Resolve(functionName string) (providerURI *url.URL, err error) {
 	f, ok := d.GetFunction(functionName)
+
 	if !ok {
 		log.Warnf("can not find function %s in cache map, will attempt cache reload", functionName)
 		if err := d.ReloadCache(); err != nil {
@@ -94,6 +96,8 @@ func (d *defaultProviderRouting) Resolve(functionName string) (providerURI *url.
 			return nil, fmt.Errorf("can not find function %s in cache map", functionName)
 		}
 	}
+
+	log.Infof("Fn: %s, annotations: %v", functionName, f.Annotations)
 
 	c, ok := (*f.Annotations)[federationProviderNameConstraint]
 	if !ok {
@@ -126,6 +130,7 @@ func ensureAnnotation(f *types.FunctionDeployment, defaultValue string) {
 
 func (d *defaultProviderRouting) matchBasedOnName(v string) *url.URL {
 	for _, u := range d.providers {
+
 		if strings.EqualFold(getHostNameWithoutPorts(u), v) {
 			return u
 		}
@@ -135,7 +140,8 @@ func (d *defaultProviderRouting) matchBasedOnName(v string) *url.URL {
 }
 
 func getHostNameWithoutPorts(v *url.URL) string {
-	return strings.Split(v.Host, ":")[0]
+	// return strings.Split(v.Host, ":")[0]
+	return v.String()
 }
 
 func (d *defaultProviderRouting) AddFunction(f *types.FunctionDeployment) {

--- a/routing/provider_test.go
+++ b/routing/provider_test.go
@@ -28,8 +28,8 @@ func Test_defaultProviderRouting_Resolve(t *testing.T) {
 			name: "provider a is resolved",
 			fields: fields{
 				cache: map[string]*types.FunctionDeployment{
-					"echo": {Service: "echo", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-a"}},
-					"cat":  {Service: "cat", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-b"}},
+					"echo": {Service: "echo", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-a:8080"}},
+					"cat":  {Service: "cat", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-b:8080"}},
 				},
 				providers: map[string]*url.URL{
 					"faas-provider-a": parseURL("http://faas-provider-a:8080"),
@@ -42,12 +42,12 @@ func Test_defaultProviderRouting_Resolve(t *testing.T) {
 			name: "provider b is resolved",
 			fields: fields{
 				cache: map[string]*types.FunctionDeployment{
-					"echo": {Service: "echo", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-a"}},
-					"cat":  {Service: "cat", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-b"}},
+					"echo": {Service: "echo", Annotations: &map[string]string{federationProviderNameConstraint: "http://faas-provider-a:8080"}},
+					"cat":  {Service: "cat", Annotations: &map[string]string{federationProviderNameConstraint: "http://faas-provider-b:8080"}},
 				},
 				providers: map[string]*url.URL{
-					"faas-provider-a": parseURL("http://faas-provider-a:8080"),
-					"faas-provider-b": parseURL("http://faas-provider-b:8080"),
+					"http://faas-provider-a:8080": parseURL("http://faas-provider-a:8080"),
+					"http://faas-provider-b:8080": parseURL("http://faas-provider-b:8080"),
 				},
 				defaultProvider: "http://faas-provider-a:8080",
 			}, args: args{functionName: "cat"}, wantProviderHostName: "faas-provider-b:8080", wantErr: false,
@@ -56,7 +56,7 @@ func Test_defaultProviderRouting_Resolve(t *testing.T) {
 			name: "default provider is resolved, when constraint is missing",
 			fields: fields{
 				cache: map[string]*types.FunctionDeployment{
-					"echo": {Service: "echo", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-a"}},
+					"echo": {Service: "echo", Annotations: &map[string]string{federationProviderNameConstraint: "faas-provider-a:8080"}},
 					"cat":  {Service: "cat", Annotations: &map[string]string{}},
 				},
 				providers: map[string]*url.URL{

--- a/vendor/github.com/gorilla/mux/go.mod
+++ b/vendor/github.com/gorilla/mux/go.mod
@@ -1,1 +1,3 @@
 module github.com/gorilla/mux
+
+go 1.13

--- a/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
+++ b/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
@@ -134,6 +134,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	}
 
 	start := time.Now()
+	log.Printf("proxying to: %s %s %s\n", proxyReq.Host, proxyReq.URL, proxyReq.RequestURI)
 	response, err := proxyClient.Do(proxyReq.WithContext(ctx))
 	seconds := time.Since(start)
 

--- a/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
+++ b/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
@@ -134,7 +134,6 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 	}
 
 	start := time.Now()
-	log.Printf("proxying to: %s %s %s\n", proxyReq.Host, proxyReq.URL, proxyReq.RequestURI)
 	response, err := proxyClient.Do(proxyReq.WithContext(ctx))
 	seconds := time.Since(start)
 

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -16,9 +16,3 @@ type AsyncReport struct {
 type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`
 }
-
-// Secret for underlying orchestrator
-type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
-}

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33
 )
+
+go 1.13

--- a/vendor/github.com/sirupsen/logrus/terminal_check_bsd.go
+++ b/vendor/github.com/sirupsen/logrus/terminal_check_bsd.go
@@ -10,3 +10,4 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
+

--- a/vendor/github.com/sirupsen/logrus/terminal_check_unix.go
+++ b/vendor/github.com/sirupsen/logrus/terminal_check_unix.go
@@ -10,3 +10,4 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
+


### PR DESCRIPTION
Use a cache key of IP/port

This change moves away from using a hostname as a key, because
sometimes, within a Pod, the IP is the same i.e. 127.0.0.1, but
the port will be different. This change uses the full URL instead
as a key.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>