### PR TITLE
Use license-check docker image instead of curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM teamserverless/license-check:0.3.6 as license-check
+
 FROM golang:1.11 as build
 
 RUN mkdir -p /go/src/github.com/openfaas-incubator/faas-federation/
@@ -14,9 +16,8 @@ COPY vendor   vendor
 COPY version  version
 COPY main.go  main.go
 
+COPY --from=license-check /license-check /usr/bin/
 
-RUN curl -sL https://github.com/alexellis/license-check/releases/download/0.2.2/license-check > /usr/bin/license-check \
-   && chmod +x /usr/bin/license-check
 RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Author(s)"
 
 RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") \


### PR DESCRIPTION
Optimizes Docker builds by copying from license-check Docker image instead of using curl to download the tool.

Tested by running `make build` and license-check passing successfully.

Ref: https://github.com/openfaas/faas/issues/1440